### PR TITLE
Fixed the module name, removed .xml

### DIFF
--- a/Ajax Newsletter/app/etc/Boolfly_Newsletter.xml
+++ b/Ajax Newsletter/app/etc/Boolfly_Newsletter.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <config>
     <modules>
-        <Boolfly_Newsletter.xml>
+        <Boolfly_Newsletter>
             <active>true</active>
             <codePool>local</codePool>
-        </Boolfly_Newsletter.xml>
+        </Boolfly_Newsletter>
     </modules>
 </config>


### PR DESCRIPTION
Also changing the location of this file from "/Ajax Newsletter/etc/Boolfly_Newsletter.xml" to "/Ajax Newsletter/etc/modules/Boolfly_Newsletter.xml" would allow you to copy the module straight into the code.

Other than that it was very helpful, thank you. I would have made the change myself but you have the repository locked down.